### PR TITLE
Fixes #4; adds a 'between' statement to number evaluation.  Lessons l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,10 @@ The most complex criteria mechanism, `has` will evaluate the test data (first ar
   * trait (required) - the name of a property to find on data object.  If comparison and value are omitted, the evaluation will simply verify the existence of the property on the object.
   * comparison (optional) - one of an existing set of comparison instructions :
     * equals (string, date, number, object)
-    * like (string)
     * below (string, date, number, object)
     * above (string, date, number, object)
+    * between (number)
+    * like (string)
     * longer (string, date, number, object)
     * shorter (string, date, number, object)
     * older (date)
@@ -114,7 +115,8 @@ Possible comparisons are:
  * (`numeric`) - [alias: "shorter"] a less-than-or-equal-to check that the comparison number is smaller than the check value.
  * (`object`) - an array or object is said to be "below" another if it is fully contained in the other.  That is: if the comparison object contains the data object, then the data object is below the comparison object.  If the objects are equal, the `below` comparison is inherently false.  If the data object is a non-array object but the comparison object is an array, then the [_.difference()](https://lodash.com/docs#difference) comparison is done between the keys of the data object and the comparison array.  If both data and comparison objects are arrays, a lodash [_.difference()](https://lodash.com/docs#difference) between comparison and data is compare with `[]`, indicating that the data object fully contains the comparison object.
  * (`string`) - performs a javascript string "less-than-or-equal" comparison.  As a loosely-typed language, this could be anything, really.
-
+##### between
+ * (`number`) - a numeric evaluator that checks to see if the comparison value is greater than, or equal to, the lesser of two bounds and simultaneously less than, or equal to, the greater of two bounds.  This method expects array notation from criteria, and will default to array notation when the supplied value does not comply.  Accepts `Number` values from `Number.NEGATIVE_INFINITY` to `Number.POSITIVE_INFINITY`.
 ##### like
  * (`string`) - a **non-strict** check that the `toLowerCase()` comparison string is equal to the `toString().toLowerCase()` check value.
 

--- a/lib/comparators/number.js
+++ b/lib/comparators/number.js
@@ -1,5 +1,7 @@
 var debug = require('debug')('brie:knows_number'),
-  assign = require('lodash/assign');
+  assign = require('lodash/assign'),
+  cloneDeep = require('lodash/cloneDeep');
+
 module.exports = function () {
   var brie = this,
     numberHandler = {
@@ -15,9 +17,28 @@ module.exports = function () {
       above: function (baseVal, checkVal) {
         debug('Comparing "' + baseVal + '" >= "' + checkVal + '": ' + (baseVal >= parseInt(checkVal, 10)));
         return baseVal >= parseInt(checkVal, 10);
+      },
+      between: function (baseVal, checkVal) {
+        // NOTE: checkVal is a single-use argument, so won't need to be deep-cloned
+        var toCheck = Array.isArray(checkVal) ? cloneDeep(checkVal) : [0, 0];
+        // short-cutting to 1x2 array of zeros.  Will return false for mal-ormed requests.
+        debug('Evaluating "' + baseVal + '" falls between "' + JSON.stringify(toCheck) + '"');
+        debug('What is infinity, after all?' + Number.POSITIVE_INFINITY);
+        debug('What is infinity, after all?' + Number.NEGATIVE_INFINITY);
+        debug('What is infinity, after all?' + [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]);
+        toCheck.push(baseVal);
+        toCheck.sort(numericSort);
+        return (baseVal === toCheck[1]);
       }
     };
   assign(brie.determine, { "number": numberHandler });
   brie.determine.number.longer = brie.determine.number.above;
   brie.determine.number.shorter = brie.determine.number.below;
 };
+
+var numericSort = function (a, b) {
+  if (Number.isFinite(a) && Number.isFinite(b)) {
+    return a - b;
+  }
+  return 0;
+}

--- a/lib/comparators/number.js
+++ b/lib/comparators/number.js
@@ -23,9 +23,6 @@ module.exports = function () {
         var toCheck = Array.isArray(checkVal) ? cloneDeep(checkVal) : [0, 0];
         // short-cutting to 1x2 array of zeros.  Will return false for mal-ormed requests.
         debug('Evaluating "' + baseVal + '" falls between "' + JSON.stringify(toCheck) + '"');
-        debug('What is infinity, after all?' + Number.POSITIVE_INFINITY);
-        debug('What is infinity, after all?' + Number.NEGATIVE_INFINITY);
-        debug('What is infinity, after all?' + [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY]);
         toCheck.push(baseVal);
         toCheck.sort(numericSort);
         return (baseVal === toCheck[1]);

--- a/test/evaluators/complex.js
+++ b/test/evaluators/complex.js
@@ -2,14 +2,14 @@
  * Created by j.corns on 2/22/17.
  */
 
-var assert = require("assert");
+var assert = require('assert');
 var brie = require('../../lib/brie');
 module.exports = function () {
   describe('#complex evaluation', function () {
     before(function () {
       this.checkData = {
         id: 123456789,
-        hasStringValue: "a string check value",
+        hasStringValue: 'a string check value',
         hasNumberValue: 181818,
         hasObjectValue: { a: 1, b: 2 },
         hasDateValue: new Date(),
@@ -23,192 +23,202 @@ module.exports = function () {
       };
       this.features = {
         // combination comparisons
-        // implied "all"
-        "canCheckComplexAll": {
-          "criteria": [
+        // implied 'all'
+        'canCheckNoTrait': {
+          'criteria': [
             {
-              "has": {
-                "trait": "hasNumberValue",
-                "comparison": "below",
-                "value": 5
-              }
-            },
-            {
-              "has": {
-                "trait": "hasStringValue",
-                "comparison": "equals",
-                "value": "a string check value"
+              'has': {
+                'comparison': 'equals',
+                'value': 'anything'
               }
             }
           ]
         },
-        // explicit "any"
-        "canCheckComplexAny": {
-          "criteria": [
+        'canCheckComplexAll': {
+          'criteria': [
             {
-              "has": {
-                "trait": "hasNumberValue",
-                "comparison": "below",
-                "value": 9999999
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'below',
+                'value': 5
               }
             },
             {
-              "has": {
-                "trait": "hasStringValue",
-                "comparison": "equals",
-                "value": "a string check value"
+              'has': {
+                'trait': 'hasStringValue',
+                'comparison': 'equals',
+                'value': 'a string check value'
+              }
+            }
+          ]
+        },
+        // explicit 'any'
+        'canCheckComplexAny': {
+          'criteria': [
+            {
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'below',
+                'value': 9999999
+              }
+            },
+            {
+              'has': {
+                'trait': 'hasStringValue',
+                'comparison': 'equals',
+                'value': 'a string check value'
               }
             }
           ],
-          "criteriaLogic": "any"
+          'criteriaLogic': 'any'
         },
-        "canCheckSimpleAny": {
-          "criteria": [
+        'canCheckSimpleAny': {
+          'criteria': [
             {
-              "has": {
-                "trait": "hasNumberValue",
-                "comparison": "below",
-                "value": 9999999
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'below',
+                'value': 9999999
               }
             },
             {
-              "has": {
-                "trait": "hasStringValue",
-                "comparison": "equals",
-                "value": "a string check value"
+              'has': {
+                'trait': 'hasStringValue',
+                'comparison': 'equals',
+                'value': 'a string check value'
               }
             }
           ],
-          "criteriaLogic": "any"
+          'criteriaLogic': 'any'
         },
-        "canCheckNestedTraits": {
-          "criteria": [
+        'canCheckNestedTraits': {
+          'criteria': [
             {
-              "has": {
-                "trait": "nested.one.a",
-                "comparison": "below",
-                "value": 5
+              'has': {
+                'trait': 'nested.one.a',
+                'comparison': 'below',
+                'value': 5
               }
             }
           ]
         },
-        "canCheckBadNestedTraits": {
-          "criteria": [
+        'canCheckBadNestedTraits': {
+          'criteria': [
             {
-              "has": {
-                "trait": "nested.one.a.nope",
-                "comparison": "below",
-                "value": 5
+              'has': {
+                'trait': 'nested.one.a.nope',
+                'comparison': 'below',
+                'value': 5
               }
             }
           ]
         },
-        // "for-ids" check
-        "canCheckAllowIds": {
-          "criteria": [
+        // 'for-ids' check
+        'canCheckAllowIds': {
+          'criteria': [
             {
-              "allowIDs": [1234, 5678, 91011, 123456789]
+              'allowIDs': [1234, 5678, 91011, 123456789]
             }
           ]
         },
-        // for "percentScale" check
-        "canCheckPercentScale": {
-          "criteria": [
+        // for 'percentScale' check
+        'canCheckPercentScale': {
+          'criteria': [
             {
-              "percentScale": {
+              'percentScale': {
                 percentMin: 0,
                 percentMax: .4,
                 salt: 9,
-                testPhase: "Can Check Percent Scale"
+                testPhase: 'Can Check Percent Scale'
               }
             }
           ]
         },
-        "canCheckPercentScaleNoMin": {
-          "criteria": [
+        'canCheckPercentScaleNoMin': {
+          'criteria': [
             {
-              "percentScale": {
+              'percentScale': {
                 percentMax: .4,
                 salt: 9,
-                testPhase: "Can Check Percent Scale"
+                testPhase: 'Can Check Percent Scale'
               }
             }
           ]
         },
-        "canCheckPercentScaleNoMax": {
-          "criteria": [
+        'canCheckPercentScaleNoMax': {
+          'criteria': [
             {
-              "percentScale": {
+              'percentScale': {
                 percentMin: .4,
                 salt: 9,
-                testPhase: "Can Check Percent Scale"
+                testPhase: 'Can Check Percent Scale'
               }
             }
           ]
         },
-        "canCheckPercentScaleBadMin": {
-          "criteria": [
+        'canCheckPercentScaleBadMin': {
+          'criteria': [
             {
-              "percentScale": {
-                percentMin: "zero",
+              'percentScale': {
+                percentMin: 'zero',
                 percentMax: .4,
                 salt: 9,
-                testPhase: "Can Check Percent Scale"
+                testPhase: 'Can Check Percent Scale'
               }
             }
           ]
         },
-        "canCheckPercentScaleBadMax": {
-          "criteria": [
+        'canCheckPercentScaleBadMax': {
+          'criteria': [
             {
-              "percentScale": {
+              'percentScale': {
                 percentMin: .1,
-                percentMax: "point-four",
+                percentMax: 'point-four',
                 salt: 9,
-                testPhase: "Can Check Percent Scale"
+                testPhase: 'Can Check Percent Scale'
               }
             }
           ]
         },
-        "canCheckPercentScaleBigMin": {
-          "criteria": [
+        'canCheckPercentScaleBigMin': {
+          'criteria': [
             {
-              "percentScale": {
+              'percentScale': {
                 percentMin: 22,
                 percentMax: 72,
                 salt: 9,
-                testPhase: "Can Check Percent Scale"
+                testPhase: 'Can Check Percent Scale'
               }
             }
           ]
         },
-        "canCheckPercentScaleBigMax": {
-          "criteria": [
+        'canCheckPercentScaleBigMax': {
+          'criteria': [
             {
-              "percentScale": {
+              'percentScale': {
                 percentMin: 1,
                 percentMax: 50,
                 salt: 9,
-                testPhase: "Can Check Percent Scale"
+                testPhase: 'Can Check Percent Scale'
               }
             }
           ]
         },
-        "canCheckPercentScaleNoSalt": {
-          "criteria": [
+        'canCheckPercentScaleNoSalt': {
+          'criteria': [
             {
-              "percentScale": {
+              'percentScale': {
                 percentMin: 1,
                 percentMax: 50,
-                testPhase: "Needs Salt"
+                testPhase: 'Needs Salt'
               }
             }
           ]
         },
-        "canCheckPercentScaleNoLabel": {
-          "criteria": [
+        'canCheckPercentScaleNoLabel': {
+          'criteria': [
             {
-              "percentScale": {
+              'percentScale': {
                 percentMin: 1,
                 percentMax: 50,
                 salt: 9
@@ -216,13 +226,13 @@ module.exports = function () {
             }
           ]
         },
-        "fullCheckWithOverrides": {
-          "criteria": [
+        'fullCheckWithOverrides': {
+          'criteria': [
             {
-              "has": {
-                "trait": "hasStringValue",
-                "comparison": "equals",
-                "value": "a string check value"
+              'has': {
+                'trait': 'hasStringValue',
+                'comparison': 'equals',
+                'value': 'a string check value'
               }
             }
           ]
@@ -231,59 +241,59 @@ module.exports = function () {
       this.bSetup = brie.setup({
         data: this.checkData,
         features: this.features,
-        overrides: {"fullCheckWithOverrides" : false},
+        overrides: {'fullCheckWithOverrides' : false},
         showLogs: false
       });
 
     });
 
-    it('"canCheckComplexAll" should evaluate to false', function () {
-      assert(!this.bSetup.get("canCheckComplexAll"));
+    it('\'canCheckComplexAll\' should evaluate to false', function () {
+      assert(!this.bSetup.get('canCheckComplexAll'));
     });
-    it('"canCheckComplexAny" should evaluate to true', function () {
+    it('\'canCheckComplexAny\' should evaluate to true', function () {
       assert(this.bSetup.getAll());
     });
-    it('"canCheckSimpleAny" should evaluate to true', function () {
+    it('\'canCheckSimpleAny\' should evaluate to true', function () {
       assert(this.bSetup.get('canCheckSimpleAny'));
     });
-    it('"fullCheckWithOverrides" should evaluate to false', function () {
+    it('\'fullCheckWithOverrides\' should evaluate to false', function () {
       assert(!this.bSetup.getAll()['fullCheckWithOverrides']);
     });
-    it('"canCheckAllowIds" should evaluate to true', function () {
-      assert(this.bSetup.get("canCheckAllowIds"));
+    it('\'canCheckAllowIds\' should evaluate to true', function () {
+      assert(this.bSetup.get('canCheckAllowIds'));
     });
-    it('"canCheckNestedTraits" should evaluate to true', function () {
-      assert(this.bSetup.get("canCheckNestedTraits"));
+    it('\'canCheckNestedTraits\' should evaluate to true', function () {
+      assert(this.bSetup.get('canCheckNestedTraits'));
     });
-    it('"canCheckBadNestedTraits" bad trait keys should evaluate to false', function () {
-      assert(!this.bSetup.get("canCheckBadNestedTraits"));
+    it('\'canCheckBadNestedTraits\' bad trait keys should evaluate to false', function () {
+      assert(!this.bSetup.get('canCheckBadNestedTraits'));
     });
     it('percentScale should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScale") === 'boolean');
+      assert(typeof this.bSetup.get('canCheckPercentScale') === 'boolean');
     });
-    it('percentScale with no "minimum" should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScaleNoMin") === 'boolean');
+    it('percentScale with no \'minimum\' should evaluate', function () {
+      assert(typeof this.bSetup.get('canCheckPercentScaleNoMin') === 'boolean');
     });
-    it('percentScale with no "maximum" should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScaleNoMax") === 'boolean');
+    it('percentScale with no \'maximum\' should evaluate', function () {
+      assert(typeof this.bSetup.get('canCheckPercentScaleNoMax') === 'boolean');
     });
-    it('percentScale with bad "minimum" should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScaleBadMin") === 'boolean');
+    it('percentScale with bad \'minimum\' should evaluate', function () {
+      assert(typeof this.bSetup.get('canCheckPercentScaleBadMin') === 'boolean');
     });
-    it('percentScale with bad "maximum" should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScaleBadMax") === 'boolean');
+    it('percentScale with bad \'maximum\' should evaluate', function () {
+      assert(typeof this.bSetup.get('canCheckPercentScaleBadMax') === 'boolean');
     });
     it('percentScale with minimum over 1 should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScaleBigMin") === 'boolean');
+      assert(typeof this.bSetup.get('canCheckPercentScaleBigMin') === 'boolean');
     });
     it('percentScale with maximum over 1 should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScaleBigMax") === 'boolean');
+      assert(typeof this.bSetup.get('canCheckPercentScaleBigMax') === 'boolean');
     });
     it('percentScale without salt should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScaleNoSalt") === 'boolean');
+      assert(typeof this.bSetup.get('canCheckPercentScaleNoSalt') === 'boolean');
     });
     it('percentScale without label should evaluate', function () {
-      assert(typeof this.bSetup.get("canCheckPercentScaleNoLabel") === 'boolean');
+      assert(typeof this.bSetup.get('canCheckPercentScaleNoLabel') === 'boolean');
     });
   });
 };

--- a/test/evaluators/numbers.js
+++ b/test/evaluators/numbers.js
@@ -1,15 +1,18 @@
 /**
  * Created by j.corns on 2/22/17.
  */
-var assert = require("assert");
+var assert = require('assert');
 var brie = require('../../lib/brie');
+
+var debug = require('debug')('brie:tests_numbers');
+
 module.exports = function () {
 
   describe('#number evaluation', function () {
     before(function () {
       this.checkData = {
         id: 123456789,
-        hasStringValue: "a string check value",
+        hasStringValue: 'a string check value',
         hasNumberValue: 181818,
         hasObjectValue: { a: 1, b: 2 },
         hasDateValue: new Date(),
@@ -17,46 +20,90 @@ module.exports = function () {
       };
       this.features = {
         // number comparators
-        "canCheckHigherNumber": {
-          "criteria": [
+        'canCheckHigherNumber': {
+          'criteria': [
             {
-              "has": {
-                "trait": "hasNumberValue",
-                "comparison": "above",
-                "value": 1
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'above',
+                'value': 1
               }
             }
           ]
         },
-        "canCheckLowerNumber": {
-          "criteria": [
+        'canCheckLowerNumber': {
+          'criteria': [
             {
-              "has": {
-                "trait": "hasNumberValue",
-                "comparison": "below",
-                "value": 9999999
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'below',
+                'value': 9999999
               }
             }
           ]
         },
-        "canCheckEqualNumber": {
-          "criteria": [
+        'canCheckEqualNumber': {
+          'criteria': [
             {
-              "has": {
-                "trait": "hasNumberValue",
-                "comparison": "equals",
-                "value": 181818
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'equals',
+                'value': 181818
               }
             }
           ]
         },
-        "canCheckInvalidNumber": {
-          "criteria": [
+        'canCheckInvalidNumber': {
+          'criteria': [
             {
-              "has": {
-                "trait": "hasNumberValue",
-                "comparison": "equals",
-                "value": null
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'equals',
+                'value': null
+              }
+            }
+          ]
+        },
+        'canCheckBetweenNumbers': {
+          'criteria': [
+            {
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'between',
+                'value': [7, 9999999]
+              }
+            }
+          ]
+        },
+        'canCheckBetweenBadArray': {
+          'criteria': [
+            {
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'between',
+                'value': 'not an array'
+              }
+            }
+          ]
+        },
+        'canCheckBetweenInfinities': {
+          'criteria': [
+            {
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'between',
+                'value': [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]
+              }
+            }
+          ]
+        },
+        'canCheckBetweenNaNs': {
+          'criteria': [
+            {
+              'has': {
+                'trait': 'hasNumberValue',
+                'comparison': 'between',
+                'value': [null, null]
               }
             }
           ]
@@ -69,17 +116,29 @@ module.exports = function () {
         showLogs: false
       });
     });
-    it('"canCheckHigherNumber" should evaluate to true', function () {
-      assert(this.bSetup.get("canCheckHigherNumber"));
+    it('\'canCheckHigherNumber\' should evaluate to true', function () {
+      assert(this.bSetup.get('canCheckHigherNumber'));
     });
-    it('"canCheckLowerNumber" should evaluate to true', function () {
-      assert(this.bSetup.get("canCheckLowerNumber"));
+    it('\'canCheckLowerNumber\' should evaluate to true', function () {
+      assert(this.bSetup.get('canCheckLowerNumber'));
     });
-    it('"canCheckEqualNumber" should evaluate to true', function () {
-      assert(this.bSetup.get("canCheckEqualNumber"));
+    it('\'canCheckEqualNumber\' should evaluate to true', function () {
+      assert(this.bSetup.get('canCheckEqualNumber'));
     });
-    it('"canCheckInvalidNumber" should evaluate to false', function () {
-      assert(!this.bSetup.get("canCheckInvalidNumber"));
+    it('\'canCheckInvalidNumber\' should evaluate to false', function () {
+      assert(!this.bSetup.get('canCheckInvalidNumber'));
+    });
+    it('\'canCheckBetweenNumbers\' should evaluate to true', function () {
+      assert(this.bSetup.get('canCheckBetweenNumbers'));
+    });
+    it('\'canCheckBetweenNumbers\' should evaluate to false', function () {
+      assert(!this.bSetup.get('canCheckBetweenBadArray'), ' when the passed value is not an array');
+    });
+    it('\'canCheckBetweenNumbers\' survives infinity', function () {
+      assert(!this.bSetup.get('canCheckBetweenInfinities'), 'Special case, when the bounds faile the \'Number.isFinite()\' check, that Brie evaluates this to false');
+    });
+    it('\'canCheckBetweenNumbers\' survives NaN', function () {
+      assert(!this.bSetup.get('canCheckBetweenNaNs'), 'Special case, when the bounds faile the \'Number.isFinite()\' check, that Brie evaluates this to false');
     });
   });
 };


### PR DESCRIPTION
…earned, here: the 'between' statement is a good enough shortcut, but adds some criteria complexity that is lexigraphically solvable by saying 'number is less than x and number is greater than y', which can be solved with existing methods.