### PR TITLE
Fix issue where data isn't overwritten with multiple calls to setup

### DIFF
--- a/lib/brie.js
+++ b/lib/brie.js
@@ -38,7 +38,7 @@ const brie = module.exports = (function () {
     Object.assign(functionalCriteria, optCriteria);
     features = optFeatures;
     overrides = optOverrides;
-    Object.assign(data, optContext);
+    data = optContext
     rulesEngine.setup({
       criteria: functionalCriteria,
       features: features

--- a/test/helpers/setup.js
+++ b/test/helpers/setup.js
@@ -125,5 +125,41 @@ module.exports = function () {
       });
       assert(!!(bSetup));
     });
+
+    it("replaces data when called twice", function () {
+        const fakeNumber = '8675309'
+        const features = {
+          allowId:{
+            criteria: [{
+              allowValues: {
+                trait: "aId",
+                values: [
+                  fakeNumber
+                ]
+              }
+            }]
+          }
+        }
+  
+        const b1 = brie.setup({
+          data: {
+            aId: fakeNumber
+          },
+          overrides: {},
+          features,
+        });
+
+        assert.deepEqual(b1.get('allowId'), true)
+
+        const b2 = b1.setup({
+          data: {
+            wrongId: "555555"
+          },
+          overrides: {},
+          features,
+        });
+
+        assert.deepEqual(b2.get('allowId'), false)
+    })
   });
 };


### PR DESCRIPTION
Found that when you make multiple calls to setup with data, the data from the previous call is persisted and can cause unexpected behavior.