### PR TITLE
Release: 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brie",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brie",
-      "version": "3.0.4",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "debug": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "email": "jason.corns@peopleconnect.us"
   },
   "license": "MIT",
-  "version": "3.0.4",
+  "version": "3.1.0",
   "homepage": "https://peopleconnectus.github.io/brie/",
   "main": "lib/brie",
   "repository": {


### PR DESCRIPTION
Minor release 3.1.0

Changes:

- https://github.com/peopleconnectus/brie/pull/41
  - feat: add hash_mod comparator for percentage-based rollouts on string traits like UUIDs

Second attempt at making this release, ran into an issue where maintainer could not self-approve. I just cherry-picked the commit from: https://github.com/peopleconnectus/brie/pull/42#issuecomment-3968646137,

```
git cherry-pick 45b4543c38d7b1c8daaeee0ffa3d9f71ce8387c5
```